### PR TITLE
Added missing manufacturer ID (JEDEC ID 0x5E6013)

### DIFF
--- a/RTD266xArduino/rtd266x.cpp
+++ b/RTD266xArduino/rtd266x.cpp
@@ -215,6 +215,7 @@ bool setup_chip_commands(uint32_t jedec_id)
     case 0xC8: // Bright Moon
     case 0xC2: // Macronix
     case 0x1C: // Unknown
+    case 0x5E: // Unknown
     case 0x85: // STMicroelectronics
       i2c_write_reg(0x62, 0x06); // flash write enable op code
       i2c_write_reg(0x63, 0x50); // flash write enable for volatile status register op code


### PR DESCRIPTION
Added missing manufacturer ID 0x5E (Unknown manufacturer) to `setup_chip_commands` method.

Chip's JEDEC ID was already present in the `flash_devices` array [here](https://github.com/floppes/RTD266xFlash/blob/8fa427e8ab8d13537d20e803c91e99bbc5e3c447/RTD266xArduino/rtd266x.cpp#L51).

This solves the "Unknown JEDEC ID" error reported by GUI for the chip above.